### PR TITLE
T360-647: Add filter by TypeGestiones to HistorialPage

### DIFF
--- a/src/pages/HistorialPage.ts
+++ b/src/pages/HistorialPage.ts
@@ -1,5 +1,6 @@
 import { Device, expect } from 'appwright';
 import { MobileBasePage } from '../pages/base/MobileBasePage';
+import { TypeGestiones } from '../types/InterfacesYEnums';
 
 function sleep(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));
@@ -104,5 +105,63 @@ export class HistorialPage extends MobileBasePage {
 
         // Finalmente, usa una aserción para verificar que el número total de elementos es mayor que 0
         expect(foundElementsCount).toBeGreaterThan(0);
+    }
+
+    /** Realiza la busqueda utilizando los filtros */
+    public async filtrarTipoGestiones(typeGestiones: TypeGestiones): Promise<void> {
+        const filtroTypeGestionesButton = this.locator('id', 'com.olvati.optitrack2022:id/fab_ingreso_manual');
+        await expect(filtroTypeGestionesButton).toBeVisible();
+        await filtroTypeGestionesButton.tap();
+        await sleep(5);
+
+        switch (typeGestiones) {
+            case TypeGestiones.Entregas:
+                const entregasOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Entregas"]', { exact: false });
+                await expect(entregasOption).toBeVisible();
+                await entregasOption.tap();
+
+                break;
+            case TypeGestiones.Recojos:
+                const recojosOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Recojos"]', { exact: false });
+                await expect(recojosOption).toBeVisible();
+                await recojosOption.tap();
+
+                break;
+            case TypeGestiones.GuiasLocal:
+                const guiaLocalOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Guias Local"]', { exact: false });
+                await expect(guiaLocalOption).toBeVisible();
+                await guiaLocalOption.tap();
+
+                break;
+            case TypeGestiones.GuiasNacional:
+                const guiaNacionalOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Guias Nacional"]', { exact: false });
+                await expect(guiaNacionalOption).toBeVisible();
+                await guiaNacionalOption.tap();
+
+                break;
+            case TypeGestiones.Todos:
+                const todosOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Todos"]', { exact: false });
+                await expect(todosOption).toBeVisible();
+                await todosOption.tap();
+
+                break;
+        }
+    }
+
+    public async validarFiltroEstados(isVisible: boolean): Promise<void> {
+        const filtroEstadosButton = this.locator('id', 'com.olvati.optitrack2022:id/fab_ingreso_manual');
+
+
+        if (isVisible) {
+            // Valida que exista al menos un elemento que coincida con el localizador.
+            // Esto es el equivalente a validar que el botón es "visible".
+            // La aserción esperará hasta que el conteo sea mayor o igual a 1.
+            expect(filtroEstadosButton).toBeGreaterThan(0);
+            // Alternativa: await expect(filtroEstadosButton.count()).toBeGreaterThanOrEqual(1);
+
+        } else {
+            // Valida que el conteo de elementos sea cero, es decir, que no existe.
+            expect(filtroEstadosButton).toEqual(0);
+        }
     }
 }

--- a/src/types/InterfacesYEnums.ts
+++ b/src/types/InterfacesYEnums.ts
@@ -7,3 +7,13 @@ export const NambarOption = {
 } as const;
 
 export type NambarOption = typeof NambarOption[keyof typeof NambarOption];
+
+export const TypeGestiones = {
+  Entregas: 'Entregas',
+  Recojos: 'Recojos',
+  GuiasLocal: 'Guias Local',
+  GuiasNacional: 'Guias Nacional',
+  Todos: 'Todos',
+} as const;
+
+export type TypeGestiones = typeof TypeGestiones[keyof typeof TypeGestiones];

--- a/tests/historialGestiones.spec.ts
+++ b/tests/historialGestiones.spec.ts
@@ -24,4 +24,19 @@ test('Search Gestiones - exitoso', async ({ device }) => {
     await historialGestionesPage.validateSearchSuccess()
 });
 
+test('Search Gestiones/Filtrar Tipo - exitoso', async ({ device }) => {
+    const loginPage = new LoginPage(device);
+    const gestionesPage = new GestionesPage(device);
+    const historialGestionesPage = new HistorialPage(device);
 
+    await loginPage.login('Jsrios', 'olva24');
+    await loginPage.validateSuccessfulLogin();
+    await sleep(5);
+
+    await gestionesPage.navbarOptions(NambarOption.Historial);
+    await sleep(2);
+    await historialGestionesPage.validateHistorialPage();
+    await historialGestionesPage.buscarGestiones('01 September 2025', '03 September 2025')
+    // agregar cosas 
+    await historialGestionesPage.validateSearchSuccess()
+});


### PR DESCRIPTION
Introduces TypeGestiones enum and related type, adds filtrarTipoGestiones and validarFiltroEstados methods to HistorialPage for filtering and validating filter visibility, and updates tests to cover filtering by type in historialGestiones.spec.ts.