### PR TITLE
T360-647: Add state filter validation for Gestiones history

### DIFF
--- a/src/pages/HistorialPage.ts
+++ b/src/pages/HistorialPage.ts
@@ -1,6 +1,6 @@
 import { Device, expect } from 'appwright';
 import { MobileBasePage } from '../pages/base/MobileBasePage';
-import { TypeGestiones } from '../types/InterfacesYEnums';
+import { TypeEstado, TypeGestiones } from '../types/InterfacesYEnums';
 
 function sleep(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));
@@ -108,32 +108,49 @@ export class HistorialPage extends MobileBasePage {
     }
 
     /** Realiza la busqueda utilizando los filtros */
-    public async filtrarTipoGestiones(typeGestiones: TypeGestiones): Promise<void> {
+    public async filtrarValidarFiltroTipoGestiones(typeGestiones: TypeGestiones): Promise<string> {
         const filtroTypeGestionesButton = this.locator('id', 'com.olvati.optitrack2022:id/fab_ingreso_manual');
         await expect(filtroTypeGestionesButton).toBeVisible();
         await filtroTypeGestionesButton.tap();
         await sleep(5);
+        let contador = 0;
 
         switch (typeGestiones) {
             case TypeGestiones.Entregas:
+                const entregasCount = this.locator('id', 'com.olvati.optitrack2022:id/tv_item_count_gestion')
+                const entregasCountText = await entregasCount.getText()
+                contador = parseInt(entregasCountText)
+
                 const entregasOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Entregas"]', { exact: false });
                 await expect(entregasOption).toBeVisible();
                 await entregasOption.tap();
 
                 break;
             case TypeGestiones.Recojos:
+                const recojosCount = this.locator('id', 'com.olvati.optitrack2022:id/tv_item_count_recojo_gestion_2')
+                const recojoCountText = await recojosCount.getText()
+                contador = parseInt(recojoCountText)
+
                 const recojosOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Recojos"]', { exact: false });
                 await expect(recojosOption).toBeVisible();
                 await recojosOption.tap();
 
                 break;
             case TypeGestiones.GuiasLocal:
+                const guiaLocalCount = this.locator('id', 'com.olvati.optitrack2022:id/tv_item_count_guias')
+                const guiaLocalCountText = await guiaLocalCount.getText()
+                contador = parseInt(guiaLocalCountText)
+
                 const guiaLocalOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Guias Local"]', { exact: false });
                 await expect(guiaLocalOption).toBeVisible();
                 await guiaLocalOption.tap();
 
                 break;
             case TypeGestiones.GuiasNacional:
+                const guiaNacionalCount = this.locator('id', 'com.olvati.optitrack2022:id/tv_item_count_guias_rec')
+                const guiaNacionalCountText = await guiaNacionalCount.getText()
+                contador = parseInt(guiaNacionalCountText)
+
                 const guiaNacionalOption = this.locator('xpath', '//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="Guias Nacional"]', { exact: false });
                 await expect(guiaNacionalOption).toBeVisible();
                 await guiaNacionalOption.tap();
@@ -146,22 +163,106 @@ export class HistorialPage extends MobileBasePage {
 
                 break;
         }
+
+        const baseLocator = '//android.widget.TextView[@resource-id="com.olvati.optitrack2022:id/texto_circulo"]'
+
+        // Define un límite de búsqueda. Esto es crucial para que la prueba no sea interminable
+        const searchLimit = contador > 5 ? 5 : contador
+
+        // Variable para almacenar la cuenta total de elementos encontrados
+        let foundElementsCount = 0;
+        let estadoTexto: string = '';
+
+        await sleep(5);
+        // Bucle para buscar elementos del índice 1 hasta el límite
+        for (let i = 1; i <= searchLimit; i++) {
+            // Construye el selector con el índice actual, por ejemplo, `(//...)[1]`, `(//...)[2]`, etc.
+            const locatorWithIndex = `(${baseLocator})[${i}]`;
+
+            // Usa el método de tu framework para verificar si el elemento existe en el DOM
+            // `isExisting()` o `isVisible()` son métodos comunes.
+            const elementExists = await this.locator('xpath', locatorWithIndex, { exact: false }).isVisible();
+
+            if (elementExists) {
+                // Si el elemento existe, incrementa el contador
+                foundElementsCount++;
+                if (i === 1) {
+                    const estadoElementoId = await this.isVisible('id', 'com.olvati.optitrack2022:id/txt_estado');
+
+                    if (estadoElementoId) {
+                        const primerEstadoTexto = await this.locator('id', 'com.olvati.optitrack2022:id/txt_estado').getText();
+                        estadoTexto = primerEstadoTexto;
+                    } else {
+                        const primerEstadoTexto = await this.locator('xpath', '(//android.widget.TextView[@resource-id="com.olvati.optitrack2022:id/txt_estado"])[1]', { exact: false }).getText();
+                        estadoTexto = primerEstadoTexto;
+                    }
+                }
+            } else {
+                // Si el elemento no existe (por ejemplo, [30]), significa que la lista terminó.
+                // Puedes salir del bucle para no seguir buscando innecesariamente
+                break;
+            }
+        }
+
+        // Finalmente, usa una aserción para verificar que el número total de elementos es mayor que 0
+        expect(foundElementsCount).toBeLessThanOrEqual(searchLimit);
+
+        return estadoTexto;
     }
 
-    public async validarFiltroEstados(isVisible: boolean): Promise<void> {
-        const filtroEstadosButton = this.locator('id', 'com.olvati.optitrack2022:id/fab_ingreso_manual');
-
+    public async validarFiltroEstadosVisible(isVisible: boolean): Promise<void> {
+        const isElementVisible = await this.isVisible('id', 'com.olvati.optitrack2022:id/spEstados')
 
         if (isVisible) {
-            // Valida que exista al menos un elemento que coincida con el localizador.
-            // Esto es el equivalente a validar que el botón es "visible".
-            // La aserción esperará hasta que el conteo sea mayor o igual a 1.
-            expect(filtroEstadosButton).toBeGreaterThan(0);
-            // Alternativa: await expect(filtroEstadosButton.count()).toBeGreaterThanOrEqual(1);
+            expect(isElementVisible).toBeTruthy();
 
         } else {
-            // Valida que el conteo de elementos sea cero, es decir, que no existe.
-            expect(filtroEstadosButton).toEqual(0);
+            expect(isElementVisible).toBeFalsy();
+        }
+    }
+
+    public async validarSeleccionEstado(typeEstado: TypeEstado): Promise<void> {
+        const selectorEstados = this.locator('id', 'com.olvati.optitrack2022:id/spEstados')
+        await expect(selectorEstados).toBeVisible();
+        await selectorEstados.tap();
+
+        const estadoOption = this.locator('xpath', `//android.widget.CheckedTextView[@resource-id="android:id/text1" and @text="${typeEstado.valueOf()}"]`, { exact: false });
+        await expect(estadoOption).toBeVisible();
+        await estadoOption.tap();
+        await sleep(3);
+
+        const snackbar = this.locator('id', 'com.olvati.optitrack2022:id/snackbar_text')
+        expect(snackbar).toBeVisible();
+
+        const baseLocatorEstado = '//android.widget.TextView[@resource-id="com.olvati.optitrack2022:id/txt_estado"]'
+
+        // Define un límite de búsqueda. Esto es crucial para que la prueba no sea interminable
+        const searchLimit = 5
+
+        // Variable para almacenar la cuenta total de elementos encontrados
+        let foundElementsCount = 0;
+
+        // Bucle para buscar elementos del índice 1 hasta el límite
+        for (let i = 1; i <= searchLimit; i++) {
+            // Construye el selector con el índice actual, por ejemplo, `(//...)[1]`, `(//...)[2]`, etc.
+            const locatorEstadoWithIndex = `(${baseLocatorEstado})[${i}]`;
+
+            // Usa el método de tu framework para verificar si el elemento existe en el DOM
+            // `isExisting()` o `isVisible()` son métodos comunes.
+            const estado = this.locator('xpath', locatorEstadoWithIndex, { exact: false });
+            const elementExists = await estado.isVisible();
+
+            if (elementExists) {
+                // Si el elemento existe, incrementa el contador
+                const estadoTexto = await estado.getText();
+                expect(estadoTexto).toBe(typeEstado.valueOf());
+
+                foundElementsCount++;
+            } else {
+                // Si el elemento no existe (por ejemplo, [30]), significa que la lista terminó.
+                // Puedes salir del bucle para no seguir buscando innecesariamente
+                break;
+            }
         }
     }
 }

--- a/src/types/InterfacesYEnums.ts
+++ b/src/types/InterfacesYEnums.ts
@@ -17,3 +17,18 @@ export const TypeGestiones = {
 } as const;
 
 export type TypeGestiones = typeof TypeGestiones[keyof typeof TypeGestiones];
+
+export const TypeEstado = {
+  Parcial: 'PARCIAL',
+  Recogido: 'RECOGIDO',
+  NoRecogido: 'NO RECOGIDO',
+  Registrado: 'REGISTRADO',
+  Entregado: 'ENTREGADO',
+  Motivado: 'MOTIVADO',
+  Asignadp: 'ASIGNADO',
+  EnProcesoVerificacionMesaPartes: 'EN PROCESO DE VERIFICACION POR MESA PARTES',
+  Anulado: 'ANULADO',
+  Todos: 'TODOS',
+} as const;
+
+export type TypeEstado = typeof TypeEstado[keyof typeof TypeEstado];

--- a/tests/historialGestiones.spec.ts
+++ b/tests/historialGestiones.spec.ts
@@ -1,42 +1,68 @@
 import { test } from 'appwright';
 import { LoginPage } from '../src/pages/LoginPage'; // ajusta la ruta si es diferente
 import { GestionesPage } from '../src/pages/GestionesPage';
-import { NambarOption } from '../src/types/InterfacesYEnums';
+import { NambarOption, TypeGestiones } from '../src/types/InterfacesYEnums';
 import { HistorialPage } from '../src/pages/HistorialPage';
 
 function sleep(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));
 }
 
-test('Search Gestiones - exitoso', async ({ device }) => {
+// test('Search Gestiones - exitoso', async ({ device }) => {
+//     const loginPage = new LoginPage(device);
+//     const gestionesPage = new GestionesPage(device);
+//     const historialGestionesPage = new HistorialPage(device);
+
+//     await loginPage.login('Jsrios', 'olva24');
+//     await loginPage.validateSuccessfulLogin();
+//     await sleep(5);
+
+//     await gestionesPage.navbarOptions(NambarOption.Historial);
+//     await sleep(2);
+//     await historialGestionesPage.validateHistorialPage();
+//     await historialGestionesPage.buscarGestiones('01 September 2025', '03 September 2025')
+//     await historialGestionesPage.validateSearchSuccess()
+// });
+
+// test('Search Gestiones/Filtrar visualización de selector de estados- exitoso', async ({ device }) => {
+//     const loginPage = new LoginPage(device);
+//     const gestionesPage = new GestionesPage(device);
+//     const historialGestionesPage = new HistorialPage(device);
+
+//     await loginPage.login('Jsrios', 'olva24');
+//     await sleep(3);
+//     await loginPage.validateSuccessfulLogin();
+//     await sleep(3);
+
+//     await gestionesPage.navbarOptions(NambarOption.Historial);
+//     await sleep(2);
+//     await historialGestionesPage.validateHistorialPage();
+//     await historialGestionesPage.buscarGestiones('01 September 2025', '03 September 2025')
+//     await historialGestionesPage.validateSearchSuccess()
+//     await sleep(3)
+//     await historialGestionesPage.filtrarTipoGestiones(TypeGestiones.Recojos)
+//     await sleep(3)
+//     await historialGestionesPage.validarFiltroEstadosVisible(true)
+// });
+
+test('Search Gestiones/Filtrar Tipo Gestiones Guías Nacionales - exitoso', async ({ device }) => {
     const loginPage = new LoginPage(device);
     const gestionesPage = new GestionesPage(device);
     const historialGestionesPage = new HistorialPage(device);
 
     await loginPage.login('Jsrios', 'olva24');
+    await sleep(3);
     await loginPage.validateSuccessfulLogin();
-    await sleep(5);
+    await sleep(3);
 
     await gestionesPage.navbarOptions(NambarOption.Historial);
     await sleep(2);
     await historialGestionesPage.validateHistorialPage();
-    await historialGestionesPage.buscarGestiones('01 September 2025', '03 September 2025')
+    await historialGestionesPage.buscarGestiones('01 September 2025', '19 September 2025')
     await historialGestionesPage.validateSearchSuccess()
-});
-
-test('Search Gestiones/Filtrar Tipo - exitoso', async ({ device }) => {
-    const loginPage = new LoginPage(device);
-    const gestionesPage = new GestionesPage(device);
-    const historialGestionesPage = new HistorialPage(device);
-
-    await loginPage.login('Jsrios', 'olva24');
-    await loginPage.validateSuccessfulLogin();
-    await sleep(5);
-
-    await gestionesPage.navbarOptions(NambarOption.Historial);
-    await sleep(2);
-    await historialGestionesPage.validateHistorialPage();
-    await historialGestionesPage.buscarGestiones('01 September 2025', '03 September 2025')
-    // agregar cosas 
-    await historialGestionesPage.validateSearchSuccess()
+    await sleep(3)
+    await historialGestionesPage.filtrarValidarFiltroTipoGestiones(TypeGestiones.GuiasNacional)
+    await sleep(3)
+    await historialGestionesPage.validarFiltroEstadosVisible(true)
+    await sleep(3)
 });


### PR DESCRIPTION
Introduces TypeEstado enum and related type, and extends HistorialPage with methods to filter and validate Gestiones by type and state. Updates tests to use new filtering and validation logic for Guías Nacionales, improving test coverage for state selector visibility and correctness.